### PR TITLE
Attempt to implement basic HQL parsing logic (Closes #2)

### DIFF
--- a/hqcli/build.gradle
+++ b/hqcli/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 }
 
 application {
-    mainClass = 'org.hql.cli.AppKt'
+    mainClass = 'org.hql.hqcli.AppKt'
 }

--- a/hqcli/src/main/kotlin/org/hql/hqcli/App.kt
+++ b/hqcli/src/main/kotlin/org/hql/hqcli/App.kt
@@ -1,9 +1,73 @@
-package org.hql.cli
+package org.hql.hqcli
 
+import org.hql.query.ast.FilterExpr
 import org.hql.query.ast.QueryAST
 
 fun main(args: Array<String>) {
-    if (args.isNotEmpty()) {
-        QueryAST.create(args[0])
+    // Если передали аргументы запускаем их, если нет — запускаем микротесты
+    val queries = if (args.isNotEmpty()) {
+        listOf(args.joinToString(" "))
+    } else {
+        listOf(
+            // Тест 1: Обычный запрос
+            "SELECT name, age FROM User WHERE age > 18 AND active = 'true' LIMIT 10",
+
+            // Тест 2: Проверка приоритетов (AND сильнее OR)
+            // Ожидаем: age > 18 ИЛИ (city = 'Msk' И active = 'true')
+            "SELECT * FROM User WHERE age > 18 OR city = 'Msk' AND active = 'true'",
+
+            // Тест 3: Скобки меняют приоритет
+            // Ожидаем: (age > 18 ИЛИ city = 'Msk') И active = 'true'
+            "SELECT id FROM User WHERE (age > 18 OR city = 'Msk') AND active = 'true'"
+        )
+    }
+
+    println("Running HQL CLI...\n")
+
+    for ((i, query) in queries.withIndex()) {
+        println("=== QUERY #${i + 1} ===")
+        println("SQL: \"$query\"")
+
+        try {
+            val ast = QueryAST.create(query)
+
+            println("Parsed successfully:")
+            println(" -> Target Class: ${ast.targetClassName}")
+            println(" -> Columns:      ${if (ast.columns.isEmpty()) "*" else ast.columns.joinToString(", ")}")
+            println(" -> Limit:        ${ast.limit ?: "All"}")
+            println(" -> Logic Tree:")
+
+            // Проверка
+            val currentFilter = ast.filter
+            if (currentFilter != null) {
+                printTree(currentFilter, indent = "    ")
+            } else {
+                println("    (No filter)")
+            }
+
+        } catch (e: Exception) {
+            println("ERROR parsing query: ${e.message}")
+            e.printStackTrace()
+        }
+        println("-".repeat(40) + "\n")
+    }
+}
+
+// Рекурсивная функция для рисования дерева логики
+fun printTree(expr: FilterExpr, indent: String) {
+    when (expr) {
+        is FilterExpr.And -> {
+            println("$indent[AND]")
+            printTree(expr.left, "$indent  |")
+            printTree(expr.right, "$indent  |")
+        }
+        is FilterExpr.Or -> {
+            println("$indent[OR]")
+            printTree(expr.left, "$indent  |")
+            printTree(expr.right, "$indent  |")
+        }
+        is FilterExpr.Comparison -> {
+            println("$indent-> ${expr.field} ${expr.operator} ${expr.value}")
+        }
     }
 }

--- a/hqlib/src/main/antlr/org/hql/Expr.g4
+++ b/hqlib/src/main/antlr/org/hql/Expr.g4
@@ -1,11 +1,22 @@
 grammar Expr;
 
-prog:	(expr NEWLINE)* ;
-expr:	expr ('*'|'/') expr
-    |	expr ('+'|'-') expr
-    |	INT
-    |	'(' expr ')'
-    ;
-NEWLINE : [\r\n]+ ;
-INT     : [0-9]+ ;
+// === ПРАВИЛА ПАРСЕРА (Синтаксис) ===
 
+// Главный вход: запрос должен заканчиваться концом файла (EOF)
+root : selectQuery EOF ;
+
+// Правило для SELECT: ключевое слово + звездочка + ключевое слово + имя класса
+selectQuery : SELECT STAR FROM target=IDENTIFIER ;
+
+
+// === ПРАВИЛА ЛЕКСЕРА (Слова) ===
+
+SELECT : 'SELECT' | 'select' ;
+FROM   : 'FROM'   | 'from' ;
+STAR   : '*' ;
+
+// Имя класса: начинается с буквы, содержит буквы, цифры или подчеркивания
+IDENTIFIER : [a-zA-Z_] [a-zA-Z0-9_]* ;
+
+// Пропускаем пробелы и переносы строк
+WS : [ \t\r\n]+ -> skip ;

--- a/hqlib/src/main/antlr/org/hql/Expr.g4
+++ b/hqlib/src/main/antlr/org/hql/Expr.g4
@@ -5,18 +5,60 @@ grammar Expr;
 // Главный вход: запрос должен заканчиваться концом файла (EOF)
 root : selectQuery EOF ;
 
-// Правило для SELECT: ключевое слово + звездочка + ключевое слово + имя класса
-selectQuery : SELECT STAR FROM target=IDENTIFIER ;
+// Правило для SELECT: ключевое слово + какие столбцы + ключевое слово + имя класса
+// + опциональные условия where и limit
+selectQuery : SELECT columns FROM target=IDENTIFIER whereClause? limitClause? ;
+
+columns : STAR | columnList;
+
+ columnList : IDENTIFIER (',' IDENTIFIER)* ;
+
+whereClause : WHERE expression ;
+
+expression
+    : left=expression op=AND right=expression  # AndExpr  // Приоритет ниже
+    | left=expression op=OR right=expression   # OrExpr   // Приоритет самый низкий
+    | '(' expression ')'                       # ParenExpr
+    | condition                                # AtomExpr
+    ;
+
+// Условие: Поле + Оператор + Значение
+condition : field=IDENTIFIER op=operator value=literal ;
+
+// Список поддерживаемых операторов
+operator : OP_EQ | OP_GT | OP_LT | OP_NEQ ;
+
+// Новое правило для LIMIT
+limitClause : LIMIT count=INT_LITERAL ;
+
+// Значением может быть число или строка
+literal : INT_LITERAL | STRING_LITERAL ;
+
 
 
 // === ПРАВИЛА ЛЕКСЕРА (Слова) ===
 
 SELECT : 'SELECT' | 'select' ;
 FROM   : 'FROM'   | 'from' ;
+WHERE  : 'WHERE'  | 'where' ;
+LIMIT  : 'LIMIT'  | 'limit' ;
+
+AND : 'AND' | 'and' | '&&';
+OR  : 'OR'  | 'or'  | '||';
 STAR   : '*' ;
+
+// Операторы
+OP_EQ  : '=' ;
+OP_GT  : '>' ;
+OP_LT  : '<' ;
+OP_NEQ : '!=' | '<>' ;
 
 // Имя класса: начинается с буквы, содержит буквы, цифры или подчеркивания
 IDENTIFIER : [a-zA-Z_] [a-zA-Z0-9_]* ;
+
+// Литералы (Значения)
+INT_LITERAL    : [0-9]+ ;             // Целые числа
+STRING_LITERAL : '\'' .*? '\'' ;      // Строки в одинарных кавычках (lazy match)
 
 // Пропускаем пробелы и переносы строк
 WS : [ \t\r\n]+ -> skip ;

--- a/hqlib/src/main/kotlin/org/hql/query/ast/QueryAST.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/ast/QueryAST.kt
@@ -5,30 +5,110 @@ import org.antlr.v4.runtime.CommonTokenStream
 import org.hql.ExprLexer
 import org.hql.ExprParser
 
-// 1. Превращаем класс в data class, чтобы хранить результат
+// Структура для фильтров
+sealed class FilterExpr {
+    // Лист дерева: конкретное сравнение
+    data class Comparison(val field: String, val operator: String, val value: Any) : FilterExpr()
+
+    // Узлы дерева: логика
+    data class And(val left: FilterExpr, val right: FilterExpr) : FilterExpr()
+    data class Or(val left: FilterExpr, val right: FilterExpr) : FilterExpr()
+}
+
 data class QueryAST(
-    val targetClassName: String
+    val targetClassName: String,
+    val filter: FilterExpr? = null,
+    val limit: Int? = null,
+    val columns: List<String> = emptyList()
 ) {
     companion object {
         fun create(query: String): QueryAST {
-            // Создаем поток символов из строки
             val charStream = CharStreams.fromString(query)
-
-            // Лексер разбивает строку на токены (SELECT, *, FROM, String)
             val lexer = ExprLexer(charStream)
             val tokens = CommonTokenStream(lexer)
-
-            // Парсер строит дерево на основе токенов
             val parser = ExprParser(tokens)
 
-            // 2. Вызываем наше главное правило "root" из грамматики
+            // Важно: начинаем парсинг
             val tree = parser.root()
+            val selectCtx = tree.selectQuery()
 
-            // 3. Достаем данные из дерева
-            // root -> selectQuery -> target (это метка из грамматики) -> text
-            val className = tree.selectQuery().target.text
+            // 1. Имя класса (используем метку target из грамматики)
+            val className = selectCtx.target.text
 
-            return QueryAST(targetClassName = className)
+            // 2. Обработка колонок (раз уж ты добавил их в грамматику)
+            val columnsList = mutableListOf<String>()
+            val columnsCtx = selectCtx.columns()
+            if (columnsCtx.STAR() == null) {
+                // Если не звездочка, собираем список имен
+                val colListCtx = columnsCtx.columnList()
+                if (colListCtx != null) {
+                    colListCtx.IDENTIFIER().forEach { columnsList.add(it.text) }
+                }
+            }
+            // Если список пуст — значит выбраны все (*)
+
+            // 3. Фильтрующее условие WHERE
+            val whereCtx = selectCtx.whereClause()
+
+            val filterObj: FilterExpr? = if (whereCtx != null) {
+                val exprCtx = whereCtx.expression()
+                // Вызываем нашу рекурсивную функцию
+                mapExpression(exprCtx)
+            } else {
+                null
+            }
+
+            // 4. Ограничивающий вывод LIMIT
+            val limitCtx = selectCtx.limitClause()
+            val limitValue = limitCtx?.count?.text?.toInt()
+
+            return QueryAST(
+                targetClassName = className,
+                filter = filterObj,
+                limit = limitValue,
+                columns = columnsList
+            )
+        }
+
+        // Рекурсивная функция для превращения дерева ANTLR в наш FilterExpr
+        private fun mapExpression(ctx: ExprParser.ExpressionContext): FilterExpr {
+            return when (ctx) {
+                // Случай: left AND right
+                is ExprParser.AndExprContext -> {
+                    FilterExpr.And(
+                        left = mapExpression(ctx.left),
+                        right = mapExpression(ctx.right)
+                    )
+                }
+                // Случай: left OR right
+                is ExprParser.OrExprContext -> {
+                    FilterExpr.Or(
+                        left = mapExpression(ctx.left),
+                        right = mapExpression(ctx.right)
+                    )
+                }
+                // Случай: ( expression ) - просто проваливаемся внутрь скобок
+                is ExprParser.ParenExprContext -> {
+                    mapExpression(ctx.expression())
+                }
+                // Случай: condition (базовое сравнение)
+                is ExprParser.AtomExprContext -> {
+                    val condCtx = ctx.condition()
+                    val fieldName = condCtx.field.text
+                    val operator = condCtx.op.text
+
+                    val valueCtx = condCtx.literal()
+                    val rawValue = valueCtx.text
+
+                    val parsedValue: Any = when {
+                        valueCtx.INT_LITERAL() != null -> rawValue.toInt()
+                        else -> rawValue.trim('\'') // Удаляем кавычки у строк
+                    }
+
+                    FilterExpr.Comparison(fieldName, operator, parsedValue)
+                }
+                else -> throw IllegalStateException("Unknown expression type: ${ctx.javaClass.simpleName}")
+            }
         }
     }
 }

--- a/hqlib/src/main/kotlin/org/hql/query/ast/QueryAST.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/ast/QueryAST.kt
@@ -2,24 +2,33 @@ package org.hql.query.ast
 
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
-
 import org.hql.ExprLexer
 import org.hql.ExprParser
 
-class QueryAST {
+// 1. Превращаем класс в data class, чтобы хранить результат
+data class QueryAST(
+    val targetClassName: String
+) {
     companion object {
         fun create(query: String): QueryAST {
-            val charsStream = CharStreams.fromString(query)
+            // Создаем поток символов из строки
+            val charStream = CharStreams.fromString(query)
 
-            val lexer = ExprLexer(charsStream)
-
+            // Лексер разбивает строку на токены (SELECT, *, FROM, String)
+            val lexer = ExprLexer(charStream)
             val tokens = CommonTokenStream(lexer)
 
+            // Парсер строит дерево на основе токенов
             val parser = ExprParser(tokens)
 
-            // TODO: convert parse tree to AST
+            // 2. Вызываем наше главное правило "root" из грамматики
+            val tree = parser.root()
 
-            return QueryAST()
+            // 3. Достаем данные из дерева
+            // root -> selectQuery -> target (это метка из грамматики) -> text
+            val className = tree.selectQuery().target.text
+
+            return QueryAST(targetClassName = className)
         }
     }
 }


### PR DESCRIPTION
Implemented basic HQL grammar using ANTLR.
Supported syntax: `SELECT * FROM ClassName`.

Changes:
- Updated `Expr.g4` with SELECT rules.
- Updated `QueryAST.kt` to generate AST from the parsed tree.