### PR TITLE
extending the language's capabilities

### DIFF
--- a/hqlib/src/main/antlr/org/hql/Expr.g4
+++ b/hqlib/src/main/antlr/org/hql/Expr.g4
@@ -7,19 +7,21 @@ root : selectQuery EOF ;
 
 // Правило для SELECT: ключевое слово + какие столбцы + ключевое слово + имя класса
 // + опциональные условия where и limit
-selectQuery : SELECT columns FROM target=table additionalClause*;
+selectQuery : SELECT columns FROM target=table additionalClause* ;
 
-columns : STAR | columnList;
+columns : STAR | columnList ;
 
 columnList : column (',' column)* ;
 
 column : expression (AS name=IDENTIFIER)? ;
 
-table : className | '(' selectQuery ')' ;
+table : (className | '(' selectQuery ')') (AS name=IDENTIFIER)? joinClause? ;
+
+joinClause : (INNER | LEFT (OUTER)? | RIGHT (OUTER)? | FULL (OUTER)?)? JOIN right=table ON expr=expression ;
 
 className : IDENTIFIER ('.' IDENTIFIER)* ;
 
-additionalClause: whereClause | limitClause | offsetClause | orderClause;
+additionalClause: whereClause | limitClause | offsetClause | orderClause | groupClause | havingClause;
 
 whereClause : WHERE expression ;
 
@@ -33,6 +35,10 @@ orderList : orderElement (',' orderElement)* ;
 
 orderElement : expression (ASC | DESC)? ;
 
+groupClause : (GROUP BY | GROUPBY) columnList ;
+
+havingClause : HAVING expression ;
+
 expression
     : '(' expression ')'                             # ParenExpr
     | left=expression op=ACCESS right=IDENTIFIER     # AccessExpr
@@ -44,6 +50,7 @@ expression
 
     | left=expression op=AND right=expression        # AndExpr
     | left=expression op=OR right=expression         # OrExpr
+    | op=NOT expr=expression                         # NotExpr
 
     | name=IDENTIFIER '(' args=argList? ')'          # FunctionCallExpr
     | BOOL_LITERAL                                   # BoolLiteralExpr
@@ -62,17 +69,27 @@ operator : OP_EQ | OP_GT | OP_LT | OP_GE | OP_LE | OP_NEQ ;
 
 // === ПРАВИЛА ЛЕКСЕРА (Слова) ===
 
-SELECT : 'SELECT' | 'select' ;
-FROM   : 'FROM'   | 'from' ;
-WHERE  : 'WHERE'  | 'where' ;
-LIMIT  : 'LIMIT'  | 'limit' ;
-AS     : 'AS'     | 'as' ;
-OFFSET : 'OFFSET' | 'offset' ;
-ORDER : 'ORDER' | 'order' ;
-BY    : 'BY'    | 'by' ;
+SELECT  : 'SELECT'  | 'select'  ;
+FROM    : 'FROM'    | 'from'    ;
+WHERE   : 'WHERE'   | 'where'   ;
+LIMIT   : 'LIMIT'   | 'limit'   ;
+AS      : 'AS'      | 'as'      ;
+OFFSET  : 'OFFSET'  | 'offset'  ;
+ORDER   : 'ORDER'   | 'order'   ;
+BY      : 'BY'      | 'by'      ;
 ORDERBY : 'ORDERBY' | 'orderby' ;
-ASC    : 'ASC'    | 'asc' ;
-DESC   : 'DESC'   | 'desc' ;
+ASC     : 'ASC'     | 'asc'     ;
+DESC    : 'DESC'    | 'desc'    ;
+GROUP   : 'GROUP'   | 'group'   ;
+GROUPBY : 'GROUPBY' | 'groupby' ;
+HAVING  : 'HAVING'  | 'having'  ;
+JOIN    : 'JOIN'    | 'join'    ;
+INNER   : 'INNER'   | 'inner'   ;
+OUTER   : 'OUTER'   | 'outer'   ;
+LEFT    : 'LEFT'    | 'left'    ;
+RIGHT   : 'RIGHT'   | 'right'   ;
+FULL    : 'FULL'    | 'full'    ;
+ON      : 'ON'      | 'on'      ;
 
 PLUS : '+';
 MINUS : '-';
@@ -81,6 +98,7 @@ ACCESS : '.';
 
 AND : 'AND' | 'and' | '&&';
 OR  : 'OR'  | 'or'  | '||';
+NOT : 'NOT' | 'not' | '!';
 STAR  : '*' ;
 
 // Операторы

--- a/hqlib/src/main/kotlin/org/hql/hprof/heap/Identifier.kt
+++ b/hqlib/src/main/kotlin/org/hql/hprof/heap/Identifier.kt
@@ -12,10 +12,7 @@ class Identifier(private val value: ByteArray): Comparable<Identifier> {
         return 0
     }
 
-    override fun hashCode(): Int {
-        return (value[0] * (1 shl 24) + value[1] * (1 shl 16) + value[2] * (1 shl 8) + value[3]) +
-                (value[4] * (1 shl 24) + value[5] * (1 shl 16) + value[6] * (1 shl 8) + value[7])
-    }
+    override fun hashCode(): Int = value.contentHashCode()
 
     fun isNull() = value.all { it == 0.toByte() }
 

--- a/hqlib/src/main/kotlin/org/hql/hprof/heap/instances/Instance.kt
+++ b/hqlib/src/main/kotlin/org/hql/hprof/heap/instances/Instance.kt
@@ -1,5 +1,6 @@
 package org.hql.hprof.heap.instances
 
+import org.hql.ColumnNotFoundException
 import org.hql.hprof.heap.Class
 import org.hql.hprof.heap.Identifier
 
@@ -52,7 +53,8 @@ sealed class Instance {
         }
 
         override fun toString() = "<instance of class ${cls.name}>"
-        operator fun get(name: String): Instance = fields.getValue(name)
+        operator fun get(name: String): Instance = fields[name] ?:
+            throw ColumnNotFoundException(name, fields.keys.toList())
     }
 
     companion object {

--- a/hqlib/src/main/kotlin/org/hql/query/Cells.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/Cells.kt
@@ -56,7 +56,7 @@ interface Cell : Comparable<Cell> {
 
 data object NullCell : Cell {
     override val type: String = "null"
-    override fun toString() = "null"
+    override fun toString() = "-"
     override fun compareTo(other: Cell): Int {
         if (other is NullCell) return 0
         return super.compareTo(other)
@@ -169,7 +169,7 @@ data class ArrayCell(val instance: Instance.ArrayI) : Cell {
 
 data class StringCell(val value: String) : Cell {
     override val type: String = "string"
-    override fun toString() = "\"$value\""
+    override fun toString() = value
     override fun compareTo(other: Cell): Int {
         if (other is StringCell) return value.compareTo(other.value)
         return super.compareTo(other)
@@ -196,6 +196,6 @@ data class ClassCell(val cls: Class) : Cell {
 
 class ObjectCell(val obj: Instance.ObjectI) : Cell {
     override val type: String = obj.cls.name
-    override fun toString() = "<$type ${obj.id}>"
+    override fun toString() = "<$type>"
     override fun access(field: String): Cell = Cell.fromInstance(obj[field])
 }

--- a/hqlib/src/main/kotlin/org/hql/query/Cells.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/Cells.kt
@@ -29,6 +29,9 @@ interface Cell : Comparable<Cell> {
     infix fun or(other: Cell): Cell {
         throw IncompatibleTypesException("OR operation", type, other.type)
     }
+    operator fun not(): Cell {
+        throw IncompatibleTypesException("NOT operation", type)
+    }
 
     fun access(field: String): Cell {
         throw IncompatibleTypesException("accessing a field $field", type)
@@ -63,7 +66,7 @@ data object NullCell : Cell {
     }
 }
 
-class BooleanCell(val v: Boolean) : Cell {
+data class BooleanCell(val v: Boolean) : Cell {
     override val type: String = "boolean"
     override fun toString() = "$v"
     override fun compareTo(other: Cell): Int {
@@ -77,6 +80,9 @@ class BooleanCell(val v: Boolean) : Cell {
     override fun or(other: Cell): Cell {
         if (other is BooleanCell) return BooleanCell(v || other.v)
         return super.and(other)
+    }
+    override fun not(): Cell {
+        return BooleanCell(!v)
     }
 }
 
@@ -160,7 +166,7 @@ data class IntCell(val v: Long) : Cell {
 }
 
 data class ArrayCell(val instance: Instance.ArrayI) : Cell {
-    override val type: String = if (instance.values.isEmpty()) "[]" else "[${this[0].type}]"
+    override val type: String = if (instance.values.isEmpty()) "array<>" else "array<${this[0].type}>"
     operator fun get(i: Int) = Cell.fromInstance(instance.values[i])
     override fun toString() = instance.values.indices
         .map { i -> this[i] }
@@ -187,15 +193,38 @@ data class StringCell(val value: String) : Cell {
 
 data class ClassCell(val cls: Class) : Cell {
     override val type: String = "class"
-    override fun toString() = "<class object ${cls.name}>"
+    override fun toString() = "class<${cls.name}>"
     override fun compareTo(other: Cell): Int {
         if (other is ClassCell) return cls.id.compareTo(other.cls.id)
         return super.compareTo(other)
     }
+    override fun equals(other: Any?): Boolean {
+        return other is ClassCell && cls.id == other.cls.id
+    }
+    override fun hashCode(): Int = cls.id.hashCode()
 }
 
 class ObjectCell(val obj: Instance.ObjectI) : Cell {
     override val type: String = obj.cls.name
-    override fun toString() = "<$type>"
+    override fun toString() = "object<$type>"
     override fun access(field: String): Cell = Cell.fromInstance(obj[field])
+    override fun equals(other: Any?): Boolean {
+        return other is ObjectCell && obj.id == other.obj.id
+    }
+    override fun hashCode(): Int = obj.id.hashCode()
+}
+
+class AggregateCell(val cells: List<Cell>) : Cell {
+    override val type: String = "aggregate<${cells.first().type}>"
+    override fun toString() = "<several values>"
+    override fun equals(other: Any?): Boolean {
+        return other is AggregateCell && cells == other.cells
+    }
+    override fun hashCode(): Int = cells.hashCode()
+}
+
+class RowCell(val row: Row) : Cell {
+    override val type: String = "row"
+    override fun toString() = "<row>"
+    override fun access(field: String): Cell = row[field]
 }

--- a/hqlib/src/main/kotlin/org/hql/query/Database.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/Database.kt
@@ -10,16 +10,16 @@ import org.hql.query.tables.Table
 class Database(val heap: Heap) {
     val tables = hashMapOf<String, Table>()
 
-    fun getTable(name: String, alias: String): Table = tables.getOrPut(name) {
+    fun getTable(name: String): Table = tables.getOrPut(name) {
         when (name) {
             "coroutines" -> CoroutineTable(heap)
-            else -> ClassTable(alias, heap.getClassByName(name))
+            else -> ClassTable(heap.getClassByName(name))
         }
     }
 
     fun targetToTable(target: Target): Table {
         return when (target) {
-            is Target.Class -> getTable(target.name, target.alias)
+            is Target.Class -> getTable(target.name).withName(target.alias)
             is Target.Subquery -> query(target.ast, target.alias)
             is Target.Join -> {
                 val left = targetToTable(target.left)
@@ -39,10 +39,8 @@ class Database(val heap: Heap) {
             having = ast.having,
             limit = ast.limit,
             offset = ast.offset,
+            alias = alias
         )
-        alias?.let {
-            result.name = alias
-        }
         return result
     }
 

--- a/hqlib/src/main/kotlin/org/hql/query/Database.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/Database.kt
@@ -1,7 +1,7 @@
 package org.hql.query
 
 import org.hql.hprof.heap.Heap
-import org.hql.query.ast.DataSource
+import org.hql.query.ast.Target
 import org.hql.query.ast.QueryAST
 import org.hql.query.tables.CoroutineTable
 import org.hql.query.tables.ClassTable
@@ -10,26 +10,40 @@ import org.hql.query.tables.Table
 class Database(val heap: Heap) {
     val tables = hashMapOf<String, Table>()
 
-    fun getTable(name: String): Table = tables.getOrPut(name) {
+    fun getTable(name: String, alias: String): Table = tables.getOrPut(name) {
         when (name) {
             "coroutines" -> CoroutineTable(heap)
-            else -> ClassTable(heap.getClassByName(name))
+            else -> ClassTable(alias, heap.getClassByName(name))
         }
     }
 
-    private fun query(ast: QueryAST): Table {
-        val table = when (ast.target) {
-            is DataSource.Class -> getTable(ast.target.name)
-            is DataSource.Subquery -> query(ast.target.ast)
+    fun targetToTable(target: Target): Table {
+        return when (target) {
+            is Target.Class -> getTable(target.name, target.alias)
+            is Target.Subquery -> query(target.ast, target.alias)
+            is Target.Join -> {
+                val left = targetToTable(target.left)
+                val right = targetToTable(target.right)
+                left.join(right, target.expr, target.type, target.alias)
+            }
         }
-        return table.select(
+    }
+
+    private fun query(ast: QueryAST, alias: String? = null): Table {
+        val table = targetToTable(ast.target)
+        val result = table.select(
             columns = ast.columns,
-            columnNames = ast.columnNames,
             filter = ast.filter,
             orderBy = ast.orderBy,
+            groupBy = ast.groupBy,
+            having = ast.having,
             limit = ast.limit,
-            offset = ast.offset
+            offset = ast.offset,
         )
+        alias?.let {
+            result.name = alias
+        }
+        return result
     }
 
     fun query(query: String): Table = query(QueryAST.create(query))

--- a/hqlib/src/main/kotlin/org/hql/query/ast/QueryAST.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/ast/QueryAST.kt
@@ -63,35 +63,74 @@ private fun printTree(expr: Expression, indent: String, out: Appendable = System
             out.appendLine("$indent[FUNCTION_CALL=${expr.name}]")
             expr.args.forEach { printTree(it, "$indent  |", out = out) }
         }
+        is Expression.Not -> {
+            out.appendLine("$indent[NOT]")
+            printTree(expr.expr, "$indent  |", out = out)
+        }
     }
 }
 
-sealed class DataSource {
-    data class Class(val name: String) : DataSource() {
+enum class JoinType {
+    INNER, LEFT, RIGHT, FULL
+}
+
+sealed class Target {
+    data class Class(val name: String, val alias: String) : Target() {
         override fun print(indent: String, out: Appendable) {
-            out.appendLine("$indent -> Target Class: $name")
+            out.appendLine("$indent    Class $name")
         }
     }
-    data class Subquery(val ast: QueryAST) : DataSource() {
+    data class Subquery(val ast: QueryAST, val alias: String) : Target() {
         override fun print(indent: String, out: Appendable) {
-            out.appendLine("$indent -> Target Subquery:")
+            out.appendLine("$indent    Subquery")
             ast.printQuery(indent = "$indent    | ", out = out)
+        }
+    }
+
+    data class Join(
+        val left: Target,
+        val right: Target,
+        val expr: Expression,
+        val type: JoinType,
+        val alias: String
+    ) : Target() {
+        override fun print(indent: String, out: Appendable) {
+            out.appendLine("$indent    Join")
+            out.appendLine("$indent    | Type: ${type.name}")
+            out.appendLine("$indent    | Join condition:")
+            printTree(expr, indent = "$indent    |   ", out = out)
+            out.appendLine("$indent    | Left:")
+            left.print(indent = "$indent    |   ", out = out)
+            out.appendLine("$indent    | Right:")
+            right.print(indent = "$indent    |   ", out = out)
         }
     }
 
     abstract fun print(indent: String = "", out: Appendable = System.out)
 }
 
+data class NamedExpression(
+    val expr: Expression,
+    val name: String
+) {
+    companion object {
+        fun List<NamedExpression>.asMap(): Map<String, Expression> =
+            associate { it.name to it.expr }
+    }
+}
+
 data class QueryAST(
-    val target: DataSource,
-    val columns: List<Expression> = emptyList(),
-    val columnNames: List<String> = emptyList(),
+    val target: Target,
+    val columns: List<NamedExpression> = emptyList(),
     val filter: Expression? = null,
     val orderBy: List<Pair<Expression, SortOrder>> = emptyList(), // <sort, sortDescending>
+    val groupBy: List<NamedExpression> = emptyList(),
+    val having: Expression? = null,
     val limit: Int? = null,
     val offset: Int? = null
 ) {
     fun printQuery(indent: String = "", out: Appendable = System.out) {
+        out.appendLine("$indent -> Target:")
         target.print(indent = indent, out = out)
 
         out.append("$indent -> Columns:      ")
@@ -99,12 +138,12 @@ data class QueryAST(
             out.appendLine("${indent}ALL")
         else {
             out.appendLine()
-            columns.forEach { printTree(it, indent = "$indent    ", out = out) }
+            columns.forEach { printTree(it.expr, indent = "$indent    ", out = out) }
         }
         out.appendLine("$indent -> Limit:        ${limit ?: "All"}")
         out.appendLine("$indent -> Order:        ")
         if (orderBy.isEmpty()) {
-            out.appendLine("${indent}NONE")
+            out.appendLine("$indent      NONE")
         } else {
             out.appendLine()
             orderBy.forEach { (expr, order) ->
@@ -120,26 +159,55 @@ data class QueryAST(
         } else {
             out.appendLine("$indent    (No filter)")
         }
+
+        out.append("$indent -> Group:      ")
+        if (groupBy.isEmpty())
+            out.appendLine("$indent      NONE")
+        else {
+            out.appendLine()
+            groupBy.forEach { printTree(it.expr, indent = "$indent    ", out = out) }
+        }
     }
 
     companion object {
+        private fun targetFromContext(ctx: ExprParser.TableContext): Target {
+            val alias = ctx.name?.text ?: ctx.className()?.text ?: $$"$selectResult"
+            val a = ctx.className()?.let { Target.Class(it.text, alias) } ?:
+                Target.Subquery(createFromContext(ctx.selectQuery()), alias)
+
+            return ctx.joinClause()?.let { joinCtx ->
+                val joinType = joinCtx.LEFT()?.let {
+                    JoinType.LEFT
+                } ?: joinCtx.RIGHT()?.let {
+                    JoinType.RIGHT
+                } ?: joinCtx.FULL()?.let {
+                    JoinType.FULL
+                } ?: JoinType.INNER
+                Target.Join(
+                    left = a,
+                    right = targetFromContext(joinCtx.right),
+                    type = joinType,
+                    expr = mapExpression(joinCtx.expr),
+                    alias = $$"$joinResult"
+                )
+            } ?: a
+        }
+
         private fun createFromContext(selectCtx: ExprParser.SelectQueryContext): QueryAST {
             // 1. Имя класса либо подзапрос (используем метку target из грамматики)
-            val target = selectCtx.target.run {
-                className()?.let { DataSource.Class(it.text) } ?:
-                DataSource.Subquery(createFromContext(selectQuery()))
-            }
+            val target = targetFromContext(selectCtx.target)
 
             // 2. Обработка колонок (раз уж ты добавил их в грамматику)
-            val columnsList = mutableListOf<Expression>()
-            val columnNames = mutableListOf<String>()
+            val columns = mutableListOf<NamedExpression>()
             val columnsCtx = selectCtx.columns()
             if (columnsCtx.STAR() == null) {
                 // Если не звездочка, собираем список имен
                 columnsCtx.columnList()?.column()?.forEach { column ->
                     val expr = column.expression()
-                    columnsList.add(mapExpression(expr))
-                    columnNames.add(column.name?.text ?: expr.text)
+                    columns.add(NamedExpression(
+                        mapExpression(expr),
+                        column.name?.text ?: expr.text
+                    ))
                 }
             }
             // Если список пуст — значит выбраны все (*)
@@ -176,14 +244,35 @@ data class QueryAST(
                 }
             }
 
+            // 7. Группировка вывода GROUP BY
+            val groupClauses = selectCtx.additionalClause().mapNotNull { it.groupClause() }
+            val groupBy = mutableListOf<NamedExpression>()
+            if (groupClauses.isNotEmpty()) {
+                val elements = groupClauses.single().columnList().column()
+                elements.forEach { column ->
+                    val expr = column.expression()
+                    groupBy.add(NamedExpression(
+                        mapExpression(expr),
+                        column.name?.text ?: expr.text
+                    ))
+                }
+            }
+
+            // 8. Фильтрация сгруппированных строк HAVING
+            val havingClauses = selectCtx.additionalClause().mapNotNull { it.havingClause() }
+            val havingExpr =
+                if (havingClauses.isEmpty()) null
+                else mapExpression(havingClauses.single().expression())
+
             return QueryAST(
                 target = target,
+                columns = columns,
                 filter = filterExpr,
                 limit = limitValue,
                 offset = offsetValue,
                 orderBy = orderByList,
-                columns = columnsList,
-                columnNames = columnNames
+                groupBy = groupBy,
+                having = havingExpr,
             )
         }
 
@@ -286,6 +375,12 @@ data class QueryAST(
                     Expression.Or(
                         left = mapExpression(ctx.left),
                         right = mapExpression(ctx.right)
+                    )
+                }
+                // Случай: NOT expr
+                is ExprParser.NotExprContext -> {
+                    Expression.Not(
+                        expr = mapExpression(ctx.expr)
                     )
                 }
 

--- a/hqlib/src/main/kotlin/org/hql/query/expressions/BuiltinFunctions.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/expressions/BuiltinFunctions.kt
@@ -33,48 +33,51 @@ data class FunctionScope(
     }
 
     fun stringArgument(index: Int): String {
-        val cell = args[index]
-        return (cell as? StringCell)?.value
-            ?: throw HQLQueryException("$name: argument ${index + 1} must be a string (provided: ${cell.type})")
+        return when (val cell = args[index]) {
+            is StringCell -> cell.value
+            else -> throw HQLQueryException("$name: argument ${index + 1} must be a string (provided: ${cell.type})")
+        }
     }
     fun booleanArgument(index: Int): Boolean {
-        val cell = args[index]
-        return (cell as? BooleanCell)?.v
-            ?: throw HQLQueryException("$name: argument $index must be a boolean (provided: ${cell.type})")
+        return when (val cell = args[index]) {
+            is BooleanCell -> cell.v
+            else -> throw HQLQueryException("$name: argument $index must be a boolean (provided: ${cell.type})")
+        }
     }
     fun numberArgument(index: Int): Double {
-        val cell = args[index]
-        return (cell as? IntCell)?.v?.toDouble()
-            ?: (cell as? FloatCell)?.v
-            ?: throw HQLQueryException("$name: argument $index must be a number (provided: ${cell.type})")
+        return when (val cell = args[index]) {
+            is IntCell -> cell.v.toDouble()
+            is FloatCell -> cell.v
+            else -> throw HQLQueryException("$name: argument $index must be a number (provided: ${cell.type})")
+        }
     }
     fun intArgument(index: Int): Long {
-        val cell = args[index]
-        return (cell as? IntCell)?.v
-            ?: throw HQLQueryException("$name: argument $index must be an integer (provided: ${cell.type})")
+        return when (val cell = args[index]) {
+            is IntCell -> cell.v
+            else -> throw HQLQueryException("$name: argument $index must be an integer (provided: ${cell.type})")
+        }
     }
     fun aggregateArgument(index: Int): List<Cell> {
-        val cell = args[index]
-        return (cell as? AggregateCell)?.cells
-            ?: listOf(cell)
+        return when (val cell = args[index]) {
+            is AggregateCell -> cell.cells
+            else -> listOf(cell)
+        }
     }
     fun argumentsAsNumberList(): List<Double> {
-        val values = mutableListOf<Double>()
-        args.forEachIndexed { i, cell ->
+        return args.flatMapIndexed { i, cell ->
             when (cell) {
-                is IntCell -> values.add(cell.v.toDouble())
-                is FloatCell -> values.add(cell.v)
-                is AggregateCell -> cell.cells.forEach { aggCell ->
+                is IntCell -> listOf(cell.v.toDouble())
+                is FloatCell -> listOf(cell.v)
+                is AggregateCell -> cell.cells.map { aggCell ->
                     when (aggCell) {
-                        is IntCell -> values.add(aggCell.v.toDouble())
-                        is FloatCell -> values.add(aggCell.v)
+                        is IntCell -> aggCell.v.toDouble()
+                        is FloatCell -> aggCell.v
                         else -> throw HQLQueryException("$name: arguments should be numbers or aggregates of numbers (argument ${i + 1} was ${cell.type})")
                     }
                 }
                 else -> throw HQLQueryException("$name: arguments should be numbers or aggregates of numbers (argument ${i + 1} was ${cell.type})")
             }
         }
-        return values
     }
 
     fun singleStringArgument(): String {
@@ -93,14 +96,9 @@ object BuiltinFunctions {
         }
     }
 
-    fun call(name: String, row: Row, args: List<Cell>): Cell {
-        val fn = functions[name.lowercase()] ?: error("Unknown function: $name")
-        val scope = FunctionScope(
-            name = name.lowercase(),
-            row = row,
-            args = args
-        )
-        return scope.fn()
+    operator fun get(functionName: String): FunctionScope.() -> Cell {
+        return functions[functionName.lowercase()] ?:
+            throw HQLQueryException("Unknown function '$functionName'")
     }
 
     init {

--- a/hqlib/src/main/kotlin/org/hql/query/expressions/BuiltinFunctions.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/expressions/BuiltinFunctions.kt
@@ -1,26 +1,227 @@
 package org.hql.query.expressions
 
 import org.hql.HQLQueryException
+import org.hql.query.AggregateCell
+import org.hql.query.ArrayCell
+import org.hql.query.BooleanCell
 import org.hql.query.Cell
+import org.hql.query.CharCell
+import org.hql.query.FloatCell
+import org.hql.query.IntCell
+import org.hql.query.NullCell
 import org.hql.query.Row
 import org.hql.query.StringCell
+import org.hql.query.rows.AggregateRow
+import kotlin.math.absoluteValue
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+data class FunctionScope(
+    val name: String,
+    val row: Row,
+    val args: List<Cell>
+) {
+    fun requireArgsSize(size: Int) {
+        if (args.size != size) {
+            throw HQLQueryException("$name: requires $size arguments (provided: ${args.size})")
+        }
+    }
+    fun requireNoArgs() {
+        if (args.isNotEmpty()) {
+            throw HQLQueryException("$name: doesn't accept arguments (provided: ${args.size})")
+        }
+    }
+
+    fun stringArgument(index: Int): String {
+        val cell = args[index]
+        return (cell as? StringCell)?.value
+            ?: throw HQLQueryException("$name: argument ${index + 1} must be a string (provided: ${cell.type})")
+    }
+    fun booleanArgument(index: Int): Boolean {
+        val cell = args[index]
+        return (cell as? BooleanCell)?.v
+            ?: throw HQLQueryException("$name: argument $index must be a boolean (provided: ${cell.type})")
+    }
+    fun numberArgument(index: Int): Double {
+        val cell = args[index]
+        return (cell as? IntCell)?.v?.toDouble()
+            ?: (cell as? FloatCell)?.v
+            ?: throw HQLQueryException("$name: argument $index must be a number (provided: ${cell.type})")
+    }
+    fun intArgument(index: Int): Long {
+        val cell = args[index]
+        return (cell as? IntCell)?.v
+            ?: throw HQLQueryException("$name: argument $index must be an integer (provided: ${cell.type})")
+    }
+    fun aggregateArgument(index: Int): List<Cell> {
+        val cell = args[index]
+        return (cell as? AggregateCell)?.cells
+            ?: listOf(cell)
+    }
+    fun argumentsAsNumberList(): List<Double> {
+        val values = mutableListOf<Double>()
+        args.forEachIndexed { i, cell ->
+            when (cell) {
+                is IntCell -> values.add(cell.v.toDouble())
+                is FloatCell -> values.add(cell.v)
+                is AggregateCell -> cell.cells.forEach { aggCell ->
+                    when (aggCell) {
+                        is IntCell -> values.add(aggCell.v.toDouble())
+                        is FloatCell -> values.add(aggCell.v)
+                        else -> throw HQLQueryException("$name: arguments should be numbers or aggregates of numbers (argument ${i + 1} was ${cell.type})")
+                    }
+                }
+                else -> throw HQLQueryException("$name: arguments should be numbers or aggregates of numbers (argument ${i + 1} was ${cell.type})")
+            }
+        }
+        return values
+    }
+
+    fun singleStringArgument(): String {
+        requireArgsSize(1)
+        return stringArgument(0)
+    }
+}
 
 object BuiltinFunctions {
 
-    private val functions = mutableMapOf<String, (Row, List<Cell>) -> Cell>()
+    private val functions = mutableMapOf<String, FunctionScope.() -> Cell>()
 
-    fun register(name: String, fn: (Row, List<Cell>) -> Cell) {
-        functions[name.lowercase()] = fn
+    fun register(vararg names: String, fn: FunctionScope.() -> Cell) {
+        names.forEach { name ->
+            functions[name.lowercase()] = fn
+        }
     }
 
     fun call(name: String, row: Row, args: List<Cell>): Cell {
         val fn = functions[name.lowercase()] ?: error("Unknown function: $name")
-        return fn(row, args)
+        val scope = FunctionScope(
+            name = name.lowercase(),
+            row = row,
+            args = args
+        )
+        return scope.fn()
     }
 
-    fun List<Cell>.requireSingleString(fnName: String): String {
-        if (size != 1) throw HQLQueryException("$fnName: expected 1 argument")
-        return (this[0] as? StringCell)?.value
-            ?: throw HQLQueryException("$fnName: argument must be a string")
+    init {
+        // basic functions / null checks
+        register("coalesce") {
+            args.forEach { cell ->
+                if (cell !is NullCell)
+                    return@register cell
+            }
+            NullCell
+        }
+        register("isnull") {
+            requireArgsSize(1)
+            BooleanCell(args[0] is NullCell)
+        }
+        register("ifnull") {
+            requireArgsSize(2)
+            if (args[0] is NullCell) args[1] else args[0]
+        }
+        register("if") {
+            requireArgsSize(3)
+            val cond = booleanArgument(0)
+            if (cond) args[1] else args[2]
+        }
+
+        // number functions
+        register("count") {
+            requireNoArgs()
+            if (row !is AggregateRow)
+                throw HQLQueryException("calling COUNT without or before a GROUP BY clause")
+            IntCell(row.group.size.toLong())
+        }
+        register("distinct") {
+            requireArgsSize(1)
+            val target = aggregateArgument(0)
+            val cells = mutableSetOf<Cell>()
+            cells.addAll(target)
+            IntCell(cells.size.toLong())
+        }
+        register("round") {
+            requireArgsSize(2)
+            val value = numberArgument(0)
+            val decimals = numberArgument(1)
+            val decimals10 = 10.toDouble().pow(decimals.toInt())
+            FloatCell((value * decimals10).roundToInt() / decimals10)
+        }
+        register("abs") {
+            requireArgsSize(1)
+            when (val value = args[0]) {
+                is IntCell -> IntCell(value.v.absoluteValue)
+                is FloatCell -> FloatCell(value.v.absoluteValue)
+                else -> throw HQLQueryException("abs: argument must be a number (provided: ${value.type}")
+            }
+        }
+        register("min") {
+            val values = argumentsAsNumberList()
+            if (values.isEmpty()) NullCell else FloatCell(values.min())
+        }
+        register("max") {
+            val values = argumentsAsNumberList()
+            if (values.isEmpty()) NullCell else FloatCell(values.max())
+        }
+        register("sum") {
+            val values = argumentsAsNumberList()
+            if (values.isEmpty()) NullCell else FloatCell(values.sum())
+        }
+        register("avg") {
+            val values = argumentsAsNumberList()
+            if (values.isEmpty()) NullCell else FloatCell(values.average())
+        }
+
+        // string functions
+        register("length") {
+            val value = singleStringArgument()
+            IntCell(value.length.toLong())
+        }
+        register("lower", "lcase") {
+            val value = singleStringArgument()
+            StringCell(value.lowercase())
+        }
+        register("upper", "ucase") {
+            val value = singleStringArgument()
+            StringCell(value.uppercase())
+        }
+        register("reverse") {
+            val value = singleStringArgument()
+            StringCell(value.reversed())
+        }
+        register("trim") {
+            val value = singleStringArgument()
+            StringCell(value.trim())
+        }
+        register("ltrim") {
+            val value = singleStringArgument()
+            StringCell(value.trimStart())
+        }
+        register("rtrim") {
+            val value = singleStringArgument()
+            StringCell(value.trimEnd())
+        }
+        register("substr", "substring", "mid") {
+            requireArgsSize(3)
+            val value = stringArgument(0)
+            val start = intArgument(1).toInt()
+            val length = intArgument(2).toInt()
+            StringCell(value.substring(start, start + length))
+        }
+        register("locate", "position") {
+            requireArgsSize(2)
+            val value = stringArgument(0)
+            val search = stringArgument(1)
+            IntCell(value.indexOf(search).toLong())
+        }
+        register("index") {
+            requireArgsSize(2)
+            val index = intArgument(1).toInt()
+            when (val value = args[0]) {
+                is StringCell -> CharCell(value.value[index])
+                is ArrayCell -> value[index]
+                else -> throw HQLQueryException("index: argument 1 must be a string or array (provided: ${value.type}")
+            }
+        }
     }
 }

--- a/hqlib/src/main/kotlin/org/hql/query/expressions/Expression.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/expressions/Expression.kt
@@ -44,6 +44,10 @@ sealed class Expression {
         override fun eval(row: Row): Cell = left.eval(row) or right.eval(row)
     }
 
+    data class Not(val expr: Expression) : Expression() {
+        override fun eval(row: Row): Cell = !(expr.eval(row))
+    }
+
     data class FunctionCall(val name: String, val args: List<Expression>) : Expression() {
         override fun eval(row: Row): Cell = BuiltinFunctions.call(name, row, args.map { it.eval(row) })
     }

--- a/hqlib/src/main/kotlin/org/hql/query/expressions/Expression.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/expressions/Expression.kt
@@ -49,7 +49,14 @@ sealed class Expression {
     }
 
     data class FunctionCall(val name: String, val args: List<Expression>) : Expression() {
-        override fun eval(row: Row): Cell = BuiltinFunctions.call(name, row, args.map { it.eval(row) })
+        override fun eval(row: Row): Cell {
+            val fn = BuiltinFunctions[name]
+            return FunctionScope(
+                name = name.lowercase(),
+                row = row,
+                args = args.map { it.eval(row) }
+            ).fn()
+        }
     }
 
     data class Comparison(val left: Expression, val op: String, val right: Expression) : Expression() {

--- a/hqlib/src/main/kotlin/org/hql/query/printer/TablePrinter.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/printer/TablePrinter.kt
@@ -20,7 +20,7 @@ object TablePrinter {
     ) {
         if (columns.isEmpty()) return
 
-        val rendered = rows.map { row -> row.map { it.formatForCell() } }
+        val rendered = rows.map { row -> row.map { it.toString() } }
         val widths = columns.indices.map { i ->
             val maxRowWidth = rendered.maxOfOrNull { it[i].length } ?: MIN_COLUMN_WIDTH
             max(columns[i].length, maxRowWidth)
@@ -30,16 +30,5 @@ object TablePrinter {
         for (row in rendered) {
             out.appendLine(row.indices.joinToString(" | ") { i -> row[i].padEnd(widths[i]) })
         }
-    }
-
-    /**
-     * Cell rendering tuned for tables: strings without surrounding quotes,
-     * heap objects as their class name, and null as a dash placeholder
-     */
-    private fun Cell.formatForCell(): String = when (this) {
-        is NullCell -> "-"
-        is StringCell -> value
-        is ObjectCell -> obj.cls.name
-        else -> toString()
     }
 }

--- a/hqlib/src/main/kotlin/org/hql/query/rows/AggregateRow.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/rows/AggregateRow.kt
@@ -1,0 +1,21 @@
+package org.hql.query.rows
+
+import org.hql.query.AggregateCell
+import org.hql.query.Cell
+import org.hql.query.Row
+
+
+/**
+ * A [Row] that itself contains a group of other [Row]s.
+ * Used as a result of GROUP BY operations, and is passed as
+ * an input to aggregate functions like count().
+ */
+class AggregateRow(
+    val values: Map<String, Cell>,
+    val group: List<Row>
+): Row {
+    override fun get(column: String): Cell {
+        return values[column] ?:
+            AggregateCell(group.map { row -> row[column] })
+    }
+}

--- a/hqlib/src/main/kotlin/org/hql/query/rows/EmptyRow.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/rows/EmptyRow.kt
@@ -1,0 +1,19 @@
+package org.hql.query.rows
+
+import org.hql.ColumnNotFoundException
+import org.hql.query.Cell
+import org.hql.query.NullCell
+import org.hql.query.Row
+
+/**
+ * A [Row] returning null values for the specified columns.
+ * Used as a placeholder row for outer JOIN operations.
+ */
+class EmptyRow(private val columns: List<String>): Row {
+    override fun get(column: String): Cell {
+        if (columns.contains(column)) {
+            return NullCell
+        }
+        throw ColumnNotFoundException(column, columns)
+    }
+}

--- a/hqlib/src/main/kotlin/org/hql/query/rows/EmptyRow.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/rows/EmptyRow.kt
@@ -11,9 +11,9 @@ import org.hql.query.Row
  */
 class EmptyRow(private val columns: List<String>): Row {
     override fun get(column: String): Cell {
-        if (columns.contains(column)) {
-            return NullCell
+        return when (column) {
+            in columns -> NullCell
+            else -> throw ColumnNotFoundException(column, columns)
         }
-        throw ColumnNotFoundException(column, columns)
     }
 }

--- a/hqlib/src/main/kotlin/org/hql/query/rows/JoinRow.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/rows/JoinRow.kt
@@ -1,6 +1,6 @@
 package org.hql.query.rows
 
-import org.hql.HQLException
+import org.hql.ColumnNotFoundException
 import org.hql.HQLQueryException
 import org.hql.query.Cell
 import org.hql.query.NullCell
@@ -18,31 +18,30 @@ class JoinRow(
     val secondRow: Row,
 ): Row {
     override fun get(column: String): Cell {
-        if (column == firstTableName)
-            return RowCell(firstRow)
-        if (column == secondTableName)
-            return RowCell(secondRow)
-        if (column.startsWith(firstTableName))
-            return firstRow[column.removePrefix("$firstTableName.")]
-        if (column.startsWith(secondTableName))
-            return secondRow[column.removePrefix("$secondTableName.")]
+        return when {
+            column == firstTableName -> RowCell(firstRow)
+            column == secondTableName -> RowCell(secondRow)
+            column.startsWith(firstTableName) -> firstRow[column.removePrefix("$firstTableName.")]
+            column.startsWith(secondTableName) -> secondRow[column.removePrefix("$secondTableName.")]
+            else -> {
+                val firstCell = try {
+                    firstRow[column]
+                } catch (_: ColumnNotFoundException) {
+                    null
+                }
+                val secondCell = try {
+                    secondRow[column]
+                } catch (_: ColumnNotFoundException) {
+                    null
+                }
 
-        val firstCell = try {
-            firstRow[column]
-        } catch (_: HQLException) {
-            null
+                when {
+                    firstCell == null && secondCell == null -> NullCell
+                    firstCell != null -> firstCell
+                    secondCell != null -> secondCell
+                    else -> throw HQLQueryException("conflicting column name: $column")
+                }
+            }
         }
-        val secondCell = try {
-            secondRow[column]
-        } catch (_: HQLException) {
-            null
-        }
-        if (firstCell != null && secondCell != null) {
-            throw HQLQueryException("conflicting column name: $column")
-        }
-
-        firstCell?.let { return it }
-        secondCell?.let { return it }
-        return NullCell
     }
 }

--- a/hqlib/src/main/kotlin/org/hql/query/rows/JoinRow.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/rows/JoinRow.kt
@@ -1,0 +1,48 @@
+package org.hql.query.rows
+
+import org.hql.HQLException
+import org.hql.HQLQueryException
+import org.hql.query.Cell
+import org.hql.query.NullCell
+import org.hql.query.Row
+import org.hql.query.RowCell
+
+/**
+ * A [Row] that is produced as a result of JOIN operations.
+ * Combines column values from the two child [Row]s, properly handling dot prefixes.
+ */
+class JoinRow(
+    private val firstTableName: String,
+    private val secondTableName: String,
+    val firstRow: Row,
+    val secondRow: Row,
+): Row {
+    override fun get(column: String): Cell {
+        if (column == firstTableName)
+            return RowCell(firstRow)
+        if (column == secondTableName)
+            return RowCell(secondRow)
+        if (column.startsWith(firstTableName))
+            return firstRow[column.removePrefix("$firstTableName.")]
+        if (column.startsWith(secondTableName))
+            return secondRow[column.removePrefix("$secondTableName.")]
+
+        val firstCell = try {
+            firstRow[column]
+        } catch (_: HQLException) {
+            null
+        }
+        val secondCell = try {
+            secondRow[column]
+        } catch (_: HQLException) {
+            null
+        }
+        if (firstCell != null && secondCell != null) {
+            throw HQLQueryException("conflicting column name: $column")
+        }
+
+        firstCell?.let { return it }
+        secondCell?.let { return it }
+        return NullCell
+    }
+}

--- a/hqlib/src/main/kotlin/org/hql/query/tables/ClassTable.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/tables/ClassTable.kt
@@ -8,8 +8,13 @@ import org.hql.query.rows.ClassRow
  * and the class instances acting as rows.
  */
 class ClassTable(
+    name: String,
     private val cls: Class
 ) : Table() {
+    init {
+        this.name = name
+    }
+
     override val baseColumns: List<String>
         get() = cls.instanceFieldTypes.keys.toList()
 

--- a/hqlib/src/main/kotlin/org/hql/query/tables/ClassTable.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/tables/ClassTable.kt
@@ -8,12 +8,9 @@ import org.hql.query.rows.ClassRow
  * and the class instances acting as rows.
  */
 class ClassTable(
-    name: String,
     private val cls: Class
 ) : Table() {
-    init {
-        this.name = name
-    }
+    override val name = cls.name
 
     override val baseColumns: List<String>
         get() = cls.instanceFieldTypes.keys.toList()

--- a/hqlib/src/main/kotlin/org/hql/query/tables/CoroutineTable.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/tables/CoroutineTable.kt
@@ -11,12 +11,14 @@ import org.hql.query.IntCell
 import org.hql.query.Row
 import org.hql.query.StringCell
 import org.hql.query.expressions.BuiltinFunctions
-import org.hql.query.expressions.BuiltinFunctions.requireSingleString
 
 /**
  * Table implementation over coroutine data extracted from a heap dump
  */
 class CoroutineTable(heap: Heap) : Table() {
+    init {
+        this.name = "coroutines"
+    }
 
     override val baseColumns: List<String> = DEFAULT_COLUMNS
 
@@ -38,16 +40,16 @@ class CoroutineTable(heap: Heap) : Table() {
         CacheBuilder.newBuilder().maximumSize(SUBTREE_CACHE_MAX_SIZE).build()
 
     init {
-        BuiltinFunctions.register("descendants_count") { row, _ ->
+        BuiltinFunctions.register("descendants_count") {
             val root = lookupRow(row)
             IntCell(descendantSetOf(root.instance.id.toCompactHex()).size.toLong())
         }
-        BuiltinFunctions.register("is_descendant_of") { row, args ->
-            val rootId = args.requireSingleString("is_descendant_of")
+        BuiltinFunctions.register("is_descendant_of") {
+            val rootId = singleStringArgument()
             BooleanCell(lookupRow(row) in descendantSetOf(rootId))
         }
-        BuiltinFunctions.register("is_sibling_of") { row, args ->
-            val rootId = args.requireSingleString("is_sibling_of")
+        BuiltinFunctions.register("is_sibling_of") {
+            val rootId = singleStringArgument()
             BooleanCell(lookupRow(row) in siblingSetOf(rootId))
         }
     }

--- a/hqlib/src/main/kotlin/org/hql/query/tables/CoroutineTable.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/tables/CoroutineTable.kt
@@ -16,9 +16,7 @@ import org.hql.query.expressions.BuiltinFunctions
  * Table implementation over coroutine data extracted from a heap dump
  */
 class CoroutineTable(heap: Heap) : Table() {
-    init {
-        this.name = "coroutines"
-    }
+    override val name = "coroutines"
 
     override val baseColumns: List<String> = DEFAULT_COLUMNS
 

--- a/hqlib/src/main/kotlin/org/hql/query/tables/SimpleTable.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/tables/SimpleTable.kt
@@ -7,11 +7,7 @@ import org.hql.query.Row
  * Useful for return values of operations on other tables.
  */
 class SimpleTable<R : Row>(
-    name: String,
+    override val name: String,
     override val baseColumns: List<String>,
     override val rows: List<R>
-) : Table() {
-    init {
-        this.name = name
-    }
-}
+) : Table()

--- a/hqlib/src/main/kotlin/org/hql/query/tables/SimpleTable.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/tables/SimpleTable.kt
@@ -7,6 +7,11 @@ import org.hql.query.Row
  * Useful for return values of operations on other tables.
  */
 class SimpleTable<R : Row>(
+    name: String,
     override val baseColumns: List<String>,
     override val rows: List<R>
-) : Table()
+) : Table() {
+    init {
+        this.name = name
+    }
+}

--- a/hqlib/src/main/kotlin/org/hql/query/tables/Table.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/tables/Table.kt
@@ -1,17 +1,26 @@
 package org.hql.query.tables
 
+import org.hql.HQLQueryException
 import org.hql.query.BooleanCell
 import org.hql.query.Cell
 import org.hql.query.Row
+import org.hql.query.ast.JoinType
+import org.hql.query.ast.NamedExpression
+import org.hql.query.ast.NamedExpression.Companion.asMap
 import org.hql.query.ast.SortOrder
 import org.hql.query.expressions.Expression
 import org.hql.query.printer.TablePrinter
+import org.hql.query.rows.AggregateRow
+import org.hql.query.rows.EmptyRow
+import org.hql.query.rows.JoinRow
 
 /**
  * Shared base for SQL-like tables. Subclasses provide the row source and per-row column resolution;
  * filtering, sorting, pagination, and rendering are handled here uniformly.
  */
 abstract class Table {
+    /** The name of the table */
+    lateinit var name: String
 
     /** The full set of column names this table is known to expose by default */
     protected abstract val baseColumns: List<String>
@@ -20,24 +29,24 @@ abstract class Table {
     protected abstract val rows: List<Row>
 
     fun select(
-        columns: List<Expression>,
-        columnNames: List<String>,
+        columns: List<NamedExpression>,
         filter: Expression?,
         orderBy: List<Pair<Expression, SortOrder>>,
+        groupBy: List<NamedExpression>,
+        having: Expression?,
         limit: Int?,
         offset: Int?
     ): Table {
-        val outputColumns = columnNames.ifEmpty { baseColumns }
+        val outputColumns = columns.map { it.name }.ifEmpty { baseColumns }
+        val columnsAsMap = columns.asMap()
 
         val richRows = rows.map { row ->
             if (columns.isEmpty()) row
             else {
                 // SELECT expr1 [AS name1], ... — augment the row with computed columns
-                val computed = HashMap<String, Cell>(columns.size)
-                columns.zip(columnNames).forEach { (expr, name) ->
-                    computed[name] = expr.eval(row)
+                ChainedRow(row) { column ->
+                    columnsAsMap[column]?.eval(row)
                 }
-                ChainedRow(computed, row)
             }
         }
 
@@ -47,8 +56,38 @@ abstract class Table {
             processed = processed.filter { row ->
                 val result = f.eval(row)
                 if (result !is BooleanCell)
-                    throw RuntimeException("result of a filter expression should be boolean")
+                    throw HQLQueryException("result of a filter expression should be boolean")
                 result.v
+            }
+        }
+
+        if (groupBy.isNotEmpty()) {
+            val groupedCells = mutableMapOf<List<Cell>, MutableList<Row>>()
+            val groupNames = groupBy.map { it.name }
+            processed.forEach { row ->
+                val values = groupBy.map { (expr, _) -> expr.eval(row) }
+                groupedCells.getOrPut(values) { mutableListOf() }.add(row)
+            }
+            processed = groupedCells.map { (key, rows) ->
+                val newRow = AggregateRow(
+                    groupNames.zip(key).associate { it },
+                    rows,
+                )
+
+                // a second ChainedRow is required here so that expressions with
+                // aggregate functions don't compute against the original table rows
+                ChainedRow(newRow) { column ->
+                    columnsAsMap[column]?.eval(newRow)
+                }
+            }
+
+            having?.let { f ->
+                processed = processed.filter { row ->
+                    val result = f.eval(row)
+                    if (result !is BooleanCell)
+                        throw HQLQueryException("result of a filter expression should be boolean")
+                    result.v
+                }
             }
         }
 
@@ -73,7 +112,41 @@ abstract class Table {
         offset?.let { processed = processed.drop(it) }
         limit?.let { processed = processed.take(it) }
 
-        return SimpleTable(outputColumns, processed)
+        return SimpleTable(name, outputColumns, processed)
+    }
+
+    fun join(other: Table, expr: Expression, type: JoinType, alias: String): Table {
+        val newColumns = baseColumns.map { "$name.$it" } + other.baseColumns.map { "${other.name}.$it" }
+        val rowsPresent = MutableList(rows.size) { false }
+        val othersPresent = MutableList(other.rows.size) { false }
+        val newRows = rows.flatMapIndexed { rowIndex, row ->
+            other.rows.mapIndexedNotNull { otherRowIndex, otherRow ->
+                val joinRow = JoinRow(name, other.name, row, otherRow)
+                val condResult = expr.eval(joinRow)
+                if (condResult !is BooleanCell)
+                    throw HQLQueryException("result of a join expression should be boolean")
+                if (condResult.v) {
+                    rowsPresent[rowIndex] = true
+                    othersPresent[otherRowIndex] = true
+                    joinRow
+                } else null
+            }
+        }.toMutableList()
+
+        if (type == JoinType.LEFT || type == JoinType.FULL) {
+            rowsPresent.forEachIndexed { i, present ->
+                if (!present)
+                    newRows.add(JoinRow(name, other.name, rows[i], EmptyRow(other.baseColumns)))
+            }
+        }
+        if (type == JoinType.RIGHT || type == JoinType.FULL) {
+            othersPresent.forEachIndexed { i, present ->
+                if (!present)
+                    newRows.add(JoinRow(name, other.name, EmptyRow(baseColumns), other.rows[i]))
+            }
+        }
+
+        return SimpleTable(alias, newColumns, newRows)
     }
 
     // TODO: potentially pass different printers as a strategy
@@ -84,6 +157,6 @@ abstract class Table {
 }
 
 /** [Row] that consults [overlay] first and falls back to [base] — used to layer SELECT-computed columns over base columns. */
-private class ChainedRow(private val overlay: Map<String, Cell>, private val base: Row) : Row {
-    override fun get(column: String): Cell = overlay[column] ?: base[column]
+private class ChainedRow(private val base: Row, private val overlay: (String) -> Cell?) : Row {
+    override fun get(column: String): Cell = overlay(column) ?: base[column]
 }

--- a/hqlib/src/main/kotlin/org/hql/query/tables/Table.kt
+++ b/hqlib/src/main/kotlin/org/hql/query/tables/Table.kt
@@ -20,13 +20,17 @@ import org.hql.query.rows.JoinRow
  */
 abstract class Table {
     /** The name of the table */
-    lateinit var name: String
+    protected abstract val name: String
 
     /** The full set of column names this table is known to expose by default */
     protected abstract val baseColumns: List<String>
 
     /** The base rows on which select operates */
     protected abstract val rows: List<Row>
+
+    fun withName(name: String): Table {
+        return SimpleTable(name, baseColumns, rows)
+    }
 
     fun select(
         columns: List<NamedExpression>,
@@ -35,7 +39,8 @@ abstract class Table {
         groupBy: List<NamedExpression>,
         having: Expression?,
         limit: Int?,
-        offset: Int?
+        offset: Int?,
+        alias: String?
     ): Table {
         val outputColumns = columns.map { it.name }.ifEmpty { baseColumns }
         val columnsAsMap = columns.asMap()
@@ -112,7 +117,7 @@ abstract class Table {
         offset?.let { processed = processed.drop(it) }
         limit?.let { processed = processed.take(it) }
 
-        return SimpleTable(name, outputColumns, processed)
+        return SimpleTable(alias ?: name, outputColumns, processed)
     }
 
     fun join(other: Table, expr: Expression, type: JoinType, alias: String): Table {

--- a/hqlib/src/test/kotlin/org/hql/query/QueryE2ETest.kt
+++ b/hqlib/src/test/kotlin/org/hql/query/QueryE2ETest.kt
@@ -105,20 +105,25 @@ class QueryE2ETest {
                 val buffer = ByteArrayOutputStream()
                 val printStream = PrintStream(buffer, true, StandardCharsets.UTF_8)
                 result.print(printStream)
-                val actual = buffer.toString(StandardCharsets.UTF_8).trimEnd('\n')
 
+                val expected = case.expected.trimEnd().split('\n')
+                val actual = buffer.toString(StandardCharsets.UTF_8).trimEnd().split('\n')
                 if (regenMode) {
-                    regenerated.add(QueryCase(case.query, actual))
+                    regenerated.add(QueryCase(case.query, actual.joinToString("\n")))
                     continue
                 }
-                val expected = case.expected.trimEnd('\n')
-                if (actual != expected) {
+
+                val match = expected.size == actual.size &&
+                        expected.zip(actual).all { (expectedLine, actualLine) ->
+                            expectedLine.trimEnd() == actualLine.trimEnd()
+                        }
+                if (!match) {
                     failures++
                     report.appendLine("FAIL: $hprofName  query #${idx + 1}: ${case.query}")
                     report.appendLine("--- expected ---")
-                    report.appendLine(expected)
+                    report.appendLine(expected.joinToString("\n"))
                     report.appendLine("--- actual ---")
-                    report.appendLine(actual)
+                    report.appendLine(actual.joinToString("\n"))
                     report.appendLine()
                 }
             }

--- a/hqlib/src/test/resources/expected/join_test.expected.yaml
+++ b/hqlib/src/test/resources/expected/join_test.expected.yaml
@@ -130,3 +130,42 @@ queries:
       6  | -     | nye
       6  | -     | rqk
       2  | -     | fur
+
+  - query: "select t0.id as id, t0.name as nameA, t1.name as nameB from ClassA as t0 join ClassB as t1 on t0.id = t1.id"
+    expected: |
+      id | nameA | nameB
+      3  | qnf   | pqd  
+      4  | oyi   | nyo  
+      4  | oyi   | utl  
+      4  | oyi   | toq  
+      4  | oyi   | qkd  
+      4  | oyi   | wkz  
+      3  | nqw   | pqd  
+  
+  - query: "select * from ClassA as t0 join ClassA as t1 on t0.id = t1.id"
+    expected: |
+      t0.name | t0.id | t1.name | t1.id
+      qnf     | 3     | qnf     | 3    
+      qnf     | 3     | nqw     | 3    
+      mai     | 9     | mai     | 9    
+      mai     | 9     | ymu     | 9    
+      mai     | 9     | vbj     | 9    
+      kez     | 8     | kez     | 8    
+      kez     | 8     | dqt     | 8    
+      kez     | 8     | wtn     | 8    
+      oyi     | 4     | oyi     | 4    
+      fpa     | 10    | fpa     | 10   
+      dqt     | 8     | kez     | 8    
+      dqt     | 8     | dqt     | 8    
+      dqt     | 8     | wtn     | 8    
+      ymu     | 9     | mai     | 9    
+      ymu     | 9     | ymu     | 9    
+      ymu     | 9     | vbj     | 9    
+      nqw     | 3     | qnf     | 3    
+      nqw     | 3     | nqw     | 3    
+      vbj     | 9     | mai     | 9    
+      vbj     | 9     | ymu     | 9    
+      vbj     | 9     | vbj     | 9    
+      wtn     | 8     | kez     | 8    
+      wtn     | 8     | dqt     | 8    
+      wtn     | 8     | wtn     | 8

--- a/hqlib/src/test/resources/expected/join_test.expected.yaml
+++ b/hqlib/src/test/resources/expected/join_test.expected.yaml
@@ -1,0 +1,132 @@
+queries:
+  - query: "select coalesce(ClassA.id, ClassB.id) as id, ClassA.name as nameA, ClassB.name as nameB from ClassA join ClassB on ClassA.id = ClassB.id"
+    expected: |
+      id | nameA | nameB
+      3  | qnf   | pqd  
+      4  | oyi   | nyo  
+      4  | oyi   | utl  
+      4  | oyi   | toq  
+      4  | oyi   | qkd  
+      4  | oyi   | wkz  
+      3  | nqw   | pqd
+
+  - query: "select coalesce(ClassA.id, ClassB.id) as id, ClassA.name as nameA, ClassB.name as nameB from ClassA inner join ClassB on ClassA.id = ClassB.id"
+    expected: |
+      id | nameA | nameB
+      3  | qnf   | pqd  
+      4  | oyi   | nyo  
+      4  | oyi   | utl  
+      4  | oyi   | toq  
+      4  | oyi   | qkd  
+      4  | oyi   | wkz  
+      3  | nqw   | pqd
+
+  - query: "select coalesce(ClassA.id, ClassB.id) as id, ClassA.name as nameA, ClassB.name as nameB from ClassA left join ClassB on ClassA.id = ClassB.id"
+    expected: |
+      id | nameA | nameB
+      3  | qnf   | pqd  
+      4  | oyi   | nyo  
+      4  | oyi   | utl  
+      4  | oyi   | toq  
+      4  | oyi   | qkd  
+      4  | oyi   | wkz  
+      3  | nqw   | pqd  
+      9  | mai   | -    
+      8  | kez   | -    
+      10 | fpa   | -    
+      8  | dqt   | -    
+      9  | ymu   | -    
+      9  | vbj   | -    
+      8  | wtn   | -   
+
+  - query: "select coalesce(ClassA.id, ClassB.id) as id, ClassA.name as nameA, ClassB.name as nameB from ClassA left outer join ClassB on ClassA.id = ClassB.id"
+    expected: |
+      id | nameA | nameB
+      3  | qnf   | pqd
+      4  | oyi   | nyo
+      4  | oyi   | utl
+      4  | oyi   | toq
+      4  | oyi   | qkd
+      4  | oyi   | wkz
+      3  | nqw   | pqd
+      9  | mai   | -
+      8  | kez   | -
+      10 | fpa   | -
+      8  | dqt   | -
+      9  | ymu   | -
+      9  | vbj   | -
+      8  | wtn   | -
+
+  - query: "select coalesce(ClassA.id, ClassB.id) as id, ClassA.name as nameA, ClassB.name as nameB from ClassA right join ClassB on ClassA.id = ClassB.id"
+    expected: |
+      id | nameA | nameB
+      3  | qnf   | pqd
+      4  | oyi   | nyo
+      4  | oyi   | utl
+      4  | oyi   | toq
+      4  | oyi   | qkd
+      4  | oyi   | wkz
+      3  | nqw   | pqd
+      7  | -     | rsw
+      6  | -     | nye
+      6  | -     | rqk
+      2  | -     | fur  
+
+  - query: "select coalesce(ClassA.id, ClassB.id) as id, ClassA.name as nameA, ClassB.name as nameB from ClassA right outer join ClassB on ClassA.id = ClassB.id"
+    expected: |
+      id | nameA | nameB
+      3  | qnf   | pqd
+      4  | oyi   | nyo
+      4  | oyi   | utl
+      4  | oyi   | toq
+      4  | oyi   | qkd
+      4  | oyi   | wkz
+      3  | nqw   | pqd
+      7  | -     | rsw
+      6  | -     | nye
+      6  | -     | rqk
+      2  | -     | fur  
+
+  - query: "select coalesce(ClassA.id, ClassB.id) as id, ClassA.name as nameA, ClassB.name as nameB from ClassA full join ClassB on ClassA.id = ClassB.id"
+    expected: |
+      id | nameA | nameB
+      3  | qnf   | pqd
+      4  | oyi   | nyo
+      4  | oyi   | utl
+      4  | oyi   | toq
+      4  | oyi   | qkd
+      4  | oyi   | wkz
+      3  | nqw   | pqd
+      9  | mai   | -
+      8  | kez   | -
+      10 | fpa   | -
+      8  | dqt   | -
+      9  | ymu   | -
+      9  | vbj   | -
+      8  | wtn   | -
+      7  | -     | rsw
+      6  | -     | nye
+      6  | -     | rqk
+      2  | -     | fur  
+
+  - query: "select coalesce(ClassA.id, ClassB.id) as id, ClassA.name as nameA, ClassB.name as nameB from ClassA full outer join ClassB on ClassA.id = ClassB.id"
+    expected: |
+      id | nameA | nameB
+      3  | qnf   | pqd
+      4  | oyi   | nyo
+      4  | oyi   | utl
+      4  | oyi   | toq
+      4  | oyi   | qkd
+      4  | oyi   | wkz
+      3  | nqw   | pqd
+      9  | mai   | -
+      8  | kez   | -
+      10 | fpa   | -
+      8  | dqt   | -
+      9  | ymu   | -
+      9  | vbj   | -
+      8  | wtn   | -
+      7  | -     | rsw
+      6  | -     | nye
+      6  | -     | rqk
+      2  | -     | fur

--- a/hqlib/src/test/resources/expected/null_and_trim_test.expected.yaml
+++ b/hqlib/src/test/resources/expected/null_and_trim_test.expected.yaml
@@ -1,0 +1,46 @@
+queries:
+  - query: "select * from Class"
+    expected: |
+      name 
+      -    
+      -    
+      -    
+       szs 
+       uwy 
+      -    
+       pqf 
+       dmb 
+      -    
+       pdw
+
+  - query: "select * from Class where !isnull(name)"
+    expected: |
+      name 
+       szs 
+       uwy 
+       pqf 
+       dmb 
+       pdw 
+
+  - query: "select ifnull(name, 'NULL') as name from Class"
+    expected: |
+      name 
+      NULL 
+      NULL 
+      NULL 
+       szs 
+       uwy 
+      NULL 
+       pqf 
+       dmb 
+      NULL 
+       pdw 
+
+  - query: "select trim(name) as nname from Class where !isnull(name)"
+    expected: |
+      nname
+      szs  
+      uwy  
+      pqf  
+      dmb  
+      pdw

--- a/hqlib/src/test/resources/expected/users.expected.yaml
+++ b/hqlib/src/test/resources/expected/users.expected.yaml
@@ -68,3 +68,131 @@ queries:
       User997 | Abc  | 13          
       User998 | Spb  | 20          
       User999 | Abc  | 23          
+
+  - query: "select city, count() from User group by city"
+    expected: |
+      city | count()
+      Spb  | 246    
+      Def  | 231    
+      Abc  | 264    
+      Msk  | 259    
+
+  - query: "select city, count() as count from User group by city having count > 250"
+    expected: |
+      city | count
+      Abc  | 264  
+      Msk  | 259  
+  
+  - query: "select name, age, if(age >= 18, 'adult', 'child') as status from User where name >= 'User990'"
+    expected: |
+      name    | age | status
+      User990 | 19  | adult 
+      User991 | 23  | adult 
+      User992 | 18  | adult 
+      User993 | 16  | child 
+      User994 | 26  | adult 
+      User995 | 18  | adult 
+      User996 | 29  | adult 
+      User997 | 10  | child 
+      User998 | 17  | child 
+      User999 | 20  | adult 
+  
+  - query: "select min(age) as min, max(age) as max, sum(age) as sum, avg(age) as avg from User where name >= 'User990' group by 1"
+    expected: |
+      min  | max  | sum   | avg 
+      10.0 | 29.0 | 196.0 | 19.6
+
+  - query: "select round(avg(age), 2) as a from User group by 1"
+    expected: |
+      a    
+      19.74
+
+  - query: "select round(avg(age), -1) as a from User group by 1"
+    expected: |
+      a   
+      20.0
+
+  - query: "select distinct(length) as d from (select length(name) as length from User) group by 1"
+    expected: |
+      d
+      3
+
+  - query: "select age from User group by age having abs(age - 20) <= 2 order by age"
+    expected: |
+      age
+      18 
+      19 
+      20 
+      21 
+      22 
+
+  - query: "select lower(name) as nname from User where name >= 'User990'"
+    expected: |
+      nname   
+      user990
+      user991
+      user992
+      user993
+      user994
+      user995
+      user996
+      user997
+      user998
+      user999
+
+  - query: "select upper(name) as nname from User where name >= 'User990'"
+    expected: |
+      nname  
+      USER990
+      USER991
+      USER992
+      USER993
+      USER994
+      USER995
+      USER996
+      USER997
+      USER998
+      USER999
+
+  - query: "select reverse(name) as nname from User where name >= 'User990'"
+    expected: |
+      nname  
+      099resU
+      199resU
+      299resU
+      399resU
+      499resU
+      599resU
+      699resU
+      799resU
+      899resU
+      999resU
+
+  - query: "select substr(name, 3, 4) as nname from User where name >= 'User990'"
+    expected: |
+      nname
+      r990 
+      r991 
+      r992 
+      r993 
+      r994 
+      r995 
+      r996 
+      r997 
+      r998 
+      r999 
+  
+  - query: "select name, locate(name, 'er11') as i from User where i >= 0"
+    expected: |
+      name    | i
+      User11  | 2
+      User110 | 2
+      User111 | 2
+      User112 | 2
+      User113 | 2
+      User114 | 2
+      User115 | 2
+      User116 | 2
+      User117 | 2
+      User118 | 2
+      User119 | 2


### PR DESCRIPTION
Весь новый функционал покрыт тестами.

# Группировка (клозы GROUP BY, HAVING)

Ведут себя аналогично SQL.
`GROUP BY expr1 [AS name1], expr2 [AS name2], ... [HAVING expr]`

# Соединение таблиц (клоз JOIN)

Также ведёт себя аналогично SQL.
В дополнение теперь поддерживается синтаксис имён таблиц (`SELECT FROM ... AS name`), позволяющий использовать подзапросы вида SELECT/JOIN внутри JOIN-клозов и обращаться к их колонкам.

# Поддержка простых функций

Имена и поведения функций в основном совпадают с функциями из MySQL, но местами различаются.

- Условия и проверки на NULL: `isnull(x)`, `ifnull(x, y)`, `if(cond, iftrue, iffalse)`
- `coalesce(...)` - возвращает первое не-NULL значение из аргументов
- Простые операции над числами: `round(x, digits)`, `abs(x)`
- Простые операции над строками: `length(x)`, `lower(x)`, `upper(x)`, `reverse(x)`, `trim(x)`, `ltrim(x)`, `rtrim(x)`, `substr(x, start, length)`, `locate(x, pattern)`, `index(x, i)` (index работает и с массивами)

# Агрегирующие функции

- `count()` - не принимает аргументов, возвращает количество элементов в агрегирующей строке, на которой она была вызвана
  Пример использования: `select city, count() from User group by city`
- `distinct(x)` - возвращает количество различных значений выражения x для каждой группы
- `min(...)`, `max(...)`, `sum(...)`, `avg(...)` - функции над числами. Принимают переменное количество чисел или групп чисел, поэтому могут использоваться как для отдельных значений, так и как агрегирующие функции.

# Оператор NOT

У нас его не было почему-то.

# Текущие проблемы

- Все функции, принимающие одно значение и возвращающие одно значение (`abs()`, `length()`, etc) можно сделать так, чтобы они работали и на группах. Это в принципе исправимо, я могу открыть новый PR для этого
- Для того, чтобы агрегирующие функции работали, нужно явно указать клоз GROUP BY, даже если по константе.
  Это следует из того, что функции выполняются построчно, и не имеют доступа ко всей таблице.
  (Это в том числе значит, что функции не могут менять размер таблицы, поэтому конструкции по типу `SELECT distinct(x)` для того, чтобы вернуть все значения x без дубликатов, нужно поддерживать на уровне грамматики. Возврат всех значений без дубликатов в данный момент возможен, но довольно громоздким запросом `SELECT x FROM table GROUP BY x`)

Из первых двух проблем следует, что запросы по типу "выбрать количество различных длин строки name", которые хотелось бы записать в таком виде:
`select distinct(length(name)) from User`
придётся записывать в гораздо более громоздком виде:
`select distinct(length) from (select length(name) as length from User) group by 1`

- Если сджойнить две таблицы, в которых есть одна и та же колонка (например id), попытаться сделать `SELECT id` на сджойненой таблице вернёт ошибку conflicting column name, даже если таблицы были сджойнены на условие равенства id.
  Поэтому в результирующей таблице к колонке id нужно обращаться как `TableA.id` либо `TableB.id`. А в случае full join, где обе колонки могут быть null, то `coalesce(TableA.id, TableB.id)`.